### PR TITLE
add support for blockPerLine option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,53 +44,113 @@ function PrismPlugin(opts) {
     opts.onlyIn = opts.onlyIn || defaultOnlyIn;
     opts.getSyntax = opts.getSyntax || defaultGetSyntax;
     opts.renderToken = opts.renderToken || defaultTokenRender;
+    opts.blockPerLine = opts.blockPerLine || false;
+
+    let previousBlock;
+    let previousTokens;
 
     function decorate(text, block) {
         let characters = text.characters.asMutable();
-        const string = text.text;
         const grammarName = opts.getSyntax(block);
         const grammar = Prism.languages[grammarName];
+        let tokens;
 
         if (!grammar) {
             return text.characters;
         }
 
-        const tokens = Prism.tokenize(string, grammar);
-        let offset = 0;
+        if (opts.blockPerLine && block === previousBlock) {
+            tokens = previousTokens;
+        }
 
-        function addMark(start, end, className) {
-            for (let i = start; i < end; i++) {
+        else if (opts.blockPerLine) {
+            const string = block.nodes.toArray().map(n => n.text).join('\n');
+            tokens = Prism.tokenize(string, grammar);
+            previousBlock = block;
+            previousTokens = tokens;
+        }
+
+        else {
+            const string = text.text;
+            tokens = Prism.tokenize(string, grammar);
+        }
+
+        let o = 0;
+        let start = opts.blockPerLine ? block.getOffset(text.key) : 0;
+        let end = start + text.text.length;
+
+        function addMark(s, e, className) {
+            className = 'prism-token token ' + className;
+
+            for (let i = s; i < e; i++) {
                 let char = characters.get(i);
                 let { marks } = char;
                 marks = marks.add(Slate.Mark.create({ type: MARK_TYPE, data: { className } }));
-                char = char.merge({ marks });
+                char = char.set('marks', marks);
                 characters = characters.set(i, char);
             }
+        }
+
+        function getString(token) {
+            if (typeof token === 'string') {
+                return token;
+            }
+
+            if (typeof token.content === 'string') {
+                return token.content;
+            }
+
+            return token.content.map(getString).join('');
         }
 
         function processToken(token, accu) {
             accu = accu || '';
 
+            if (typeof token !== 'string' && typeof token.content !== 'string') {
+                accu = accu + ' ' + token.type + ' ' + (token.alias || '');
+
+                for (var i =0; i < token.content.length; i++) {
+                    processToken(token.content[i], accu);
+                }
+
+                return
+            }
+
+            const string = getString(token);
+            let length = string.length;
+
+            if (opts.blockPerLine) {
+                const newlines = (string.match(/\n/mg) || []).length;
+                length -= newlines;
+            }
+
+            const offset = o;
+            const nextOffset = offset + length;
+            o = nextOffset;
+
+            if (offset < start && nextOffset <= start) {
+                return;
+            }
+
+            if (offset >= end) {
+                return;
+            }
+
+            const gap = Math.max(start - offset, 0)
+            let s = offset - start + gap;
+            let e = nextOffset - start + gap;
+
             if (typeof token === 'string') {
                 if (accu) {
-                    addMark(offset, offset + token.length, 'prism-token token ' + accu);
+                    addMark(s, e, accu);
                 }
-                offset += token.length;
             }
 
             else {
                 accu = accu + ' ' + token.type + ' ' + (token.alias || '');
 
                 if (typeof token.content === 'string') {
-                    addMark(offset, offset + token.content.length, 'prism-token token ' + accu);
-                    offset += token.content.length;
-                }
-
-                // When using token.content instead of token.matchedStr, token can be deep
-                else {
-                    for (var i =0; i < token.content.length; i++) {
-                        processToken(token.content[i], accu);
-                    }
+                    addMark(s, e, accu);
                 }
             }
         }


### PR DESCRIPTION
Hey @Soreine this solves #4.

It's a bit convoluted, but I tried to leave as much existing code in place as possible, while keeping the new logic not too crazy to understand.

Basically if `options.blockPerLine`, then the `block` passed into the decorator is assumed to be the outer-most block. And it tokenizes that outer-most block's text, and then applies the marks to the individual leaf text nodes.