### PR TITLE
Slate 32 compatibility

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -18,7 +18,7 @@ export type OptionsFormat = {
  * Default filter for code blocks
  */
 function defaultOnlyIn(node: Node): boolean {
-    return node.kind === 'block' && node.type === 'code_block';
+    return node.object === 'block' && node.type === 'code_block';
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react": "*",
     "react-dom": "*",
     "immutable": "*",
-    "slate": "^0.29.0"
+    "slate": "^0.32.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -32,10 +32,10 @@
     "immutable": "^3.8.2",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
-    "slate": "^0.29.0",
-    "slate-edit-code": "0.13.0",
+    "slate": "^0.32.0",
+    "slate-edit-code": "^0.13.0",
     "slate-hyperscript": "^0.4.6",
-    "slate-react": "^0.10.0"
+    "slate-react": "^0.11.4"
   },
   "scripts": {
     "prepublish": "babel ./lib --out-dir ./dist",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "slate": "^0.32.0",
-    "slate-edit-code": "^0.13.0",
+    "slate-edit-code": "^0.14.0",
     "slate-hyperscript": "^0.4.6",
     "slate-react": "^0.11.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2368,10 +2368,6 @@ ignore@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
-immutable@^3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
-
 immutable@^3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
@@ -2808,6 +2804,10 @@ lodash.memoize@~3.0.3:
 lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
+
+lodash@^4.1.1:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
 lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4:
   version "4.17.4"
@@ -3613,24 +3613,28 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slate-base64-serializer@^0.2.8:
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/slate-base64-serializer/-/slate-base64-serializer-0.2.8.tgz#fef19b2cb799f5bc5f6b987834048d662102a45a"
+slate-base64-serializer@^0.2.23:
+  version "0.2.23"
+  resolved "https://registry.yarnpkg.com/slate-base64-serializer/-/slate-base64-serializer-0.2.23.tgz#d19b8a29ac800135d8c359f9153ba4af6210c407"
   dependencies:
     isomorphic-base64 "^1.0.2"
 
-slate-dev-logger@^0.1.25, slate-dev-logger@^0.1.32:
+slate-dev-logger@^0.1.32:
   version "0.1.32"
   resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.32.tgz#76b73d75a149d0eac0cab134965aca14f7542888"
 
-slate-edit-code@0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/slate-edit-code/-/slate-edit-code-0.13.0.tgz#4a064a6b2f5cef7ead34e345635fd5707319e8be"
+slate-dev-logger@^0.1.39:
+  version "0.1.39"
+  resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.39.tgz#744a69b85034244713e6de51483af5713c345af4"
+
+slate-edit-code@^0.13.0:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/slate-edit-code/-/slate-edit-code-0.13.2.tgz#682a7640da076906e5b4a4c73ec0e46d31d92c62"
   dependencies:
     detect-indent "^4.0.0"
     detect-newline "^2.1.0"
     ends-with "^0.2.0"
-    immutable "^3.8.1"
+    is-hotkey "^0.1.1"
 
 slate-hyperscript@^0.4.6:
   version "0.4.6"
@@ -3640,21 +3644,21 @@ slate-hyperscript@^0.4.6:
     is-plain-object "^2.0.4"
     slate-dev-logger "^0.1.32"
 
-slate-plain-serializer@^0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/slate-plain-serializer/-/slate-plain-serializer-0.4.6.tgz#1fa04ff7c9fd74ed5cedcdfdad8120eb4c4cef6a"
+slate-plain-serializer@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/slate-plain-serializer/-/slate-plain-serializer-0.5.4.tgz#ba5a1713a50e6e9020e080c10e5869f38820dc96"
   dependencies:
-    slate-dev-logger "^0.1.32"
+    slate-dev-logger "^0.1.39"
 
-slate-prop-types@^0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/slate-prop-types/-/slate-prop-types-0.4.6.tgz#ff7927430d03fa30bfa44ead5367867b209e5985"
+slate-prop-types@^0.4.21:
+  version "0.4.21"
+  resolved "https://registry.yarnpkg.com/slate-prop-types/-/slate-prop-types-0.4.21.tgz#618214e867d44469fb7da9b8ac4ea68e9e0fa56b"
   dependencies:
-    slate-dev-logger "^0.1.32"
+    slate-dev-logger "^0.1.39"
 
-slate-react@^0.10.0:
-  version "0.10.11"
-  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.10.11.tgz#5fbfbf0da2dd726df468d788d2bd81dd578a15a3"
+slate-react@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.11.4.tgz#c24d2cb8a3724e9a41c1f3566136ab8d3fa1ac8e"
   dependencies:
     debug "^2.3.2"
     get-window "^1.1.1"
@@ -3662,18 +3666,23 @@ slate-react@^0.10.0:
     is-in-browser "^1.1.3"
     is-window "^1.0.2"
     keycode "^2.1.2"
+    lodash "^4.1.1"
     prop-types "^15.5.8"
     react-immutable-proptypes "^2.1.0"
     react-portal "^3.1.0"
     selection-is-backward "^1.0.0"
-    slate-base64-serializer "^0.2.8"
-    slate-dev-logger "^0.1.32"
-    slate-plain-serializer "^0.4.6"
-    slate-prop-types "^0.4.6"
+    slate-base64-serializer "^0.2.23"
+    slate-dev-logger "^0.1.39"
+    slate-plain-serializer "^0.5.4"
+    slate-prop-types "^0.4.21"
 
-slate@^0.29.0:
-  version "0.29.1"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.29.1.tgz#a9df98158e67f92456b9b8f38fb6d279ba8f9f7e"
+slate-schema-violations@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/slate-schema-violations/-/slate-schema-violations-0.1.2.tgz#45f2e6ed2e77c98925bb1e159bf24cad9dc7f8ac"
+
+slate@^0.32.0:
+  version "0.32.4"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.32.4.tgz#dcc971d1cf4e4b7ac158b5bac9c39c9915805435"
   dependencies:
     debug "^2.3.2"
     direction "^0.1.5"
@@ -3681,7 +3690,8 @@ slate@^0.29.0:
     is-empty "^1.0.0"
     is-plain-object "^2.0.4"
     lodash "^4.17.4"
-    slate-dev-logger "^0.1.25"
+    slate-dev-logger "^0.1.39"
+    slate-schema-violations "^0.1.2"
     type-of "^2.0.1"
 
 slice-ansi@0.0.4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3627,9 +3627,9 @@ slate-dev-logger@^0.1.39:
   version "0.1.39"
   resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.39.tgz#744a69b85034244713e6de51483af5713c345af4"
 
-slate-edit-code@^0.13.0:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/slate-edit-code/-/slate-edit-code-0.13.2.tgz#682a7640da076906e5b4a4c73ec0e46d31d92c62"
+slate-edit-code@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/slate-edit-code/-/slate-edit-code-0.14.0.tgz#8fec510957eaef9a861746d0c7f10c3ede3998d0"
   dependencies:
     detect-indent "^4.0.0"
     detect-newline "^2.1.0"


### PR DESCRIPTION
`.kind` becomes `.object`. Prevents deprecation warnings being thrown in 32 onwards.

~~Depends on https://github.com/GitbookIO/slate-edit-code/pull/35 - once that's merged and published I'll be happy to update this PR to reflect the new version in `package.json` to fully remove these warnings.~~

Bumped slate-edit-code dependency now that it's 32 compatible.